### PR TITLE
[feat] mainWindow loader must be loadFile for internal files

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -5,9 +5,10 @@ let mainWindow
 app.on('ready', () => {
 
     mainWindow = new BrowserWindow({
-
+        width: 800,
+        height: 600,
     })
 
-    mainWindow.loadURL(`File://${ __dirname }/index.html`)
+    mainWindow.loadFile('frontend/index.html')
 
 })


### PR DESCRIPTION
Hello @Natzaum,

When building an electron application and using a html local file you need to load it using loadFile()
https://www.electronjs.org/docs/latest/api/browser-window

I also recommend not leaving the BrowserWindow without properties